### PR TITLE
fix(M-D2): revert on missing pay metadata instead of silent return

### DIFF
--- a/contracts/DefifaHook.sol
+++ b/contracts/DefifaHook.sol
@@ -811,10 +811,7 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         (bool found, bytes memory metadata) =
             JBMetadataResolver.getDataFor(JBMetadataResolver.getId("pay", codeOrigin), context.payerMetadata);
 
-        if (!found) {
-           // TODO: Revert? 
-           return;
-        }
+        if (!found) revert NOTHING_TO_MINT();
 
         // Decode the metadata.
         (address _attestationDelegate, uint16[] memory _tierIdsToMint ) = abi.decode(metadata, (address, uint16[]));


### PR DESCRIPTION
Payments without proper metadata (tier IDs to mint) would enter the treasury with no NFTs minted, permanently donating to the pot with no representation and no refund mechanism.