### PR TITLE
docs(M-D4): document integer division dust loss in cashOutWeightOf

### DIFF
--- a/contracts/DefifaHook.sol
+++ b/contracts/DefifaHook.sol
@@ -274,6 +274,9 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
             - (_burnedTokens - tokensRedeemedFrom[_tierId]);
 
         // Calculate the percentage of the tier cashOut amount a single token counts for.
+        // NOTE: Integer division truncates. Up to (_totalTokensForCashoutInTier - 1) units of weight
+        // per tier are permanently unclaimable. With TOTAL_CASHOUT_WEIGHT = 1e18 and typical token
+        // counts, this amounts to negligible dust (< 1 wei per tier in most games).
         return _weight / _totalTokensForCashoutInTier;
     }
 


### PR DESCRIPTION
The per-token weight calculation truncates, leaving up to (tokensInTier - 1) units of weight permanently unclaimable per tier. This is inherent to integer division and negligible in practice.