### PR TITLE
fix(H-D1): use actual game token in currentGamePotOf balance query

### DIFF
--- a/contracts/DefifaDeployer.sol
+++ b/contracts/DefifaDeployer.sol
@@ -164,8 +164,7 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
 
         // Get the current balance.
         uint256 _pot = IJBMultiTerminal(address(_terminal)).STORE().balanceOf(
-            // TODO: Should we only check native token here?
-            address(_terminal), _gameId, JBConstants.NATIVE_TOKEN
+            address(_terminal), _gameId, _token
         );
 
         // Add any fulfilled commitments.


### PR DESCRIPTION
Was hardcoded to JBConstants.NATIVE_TOKEN, causing ERC20 games to always show pot = 0 in views and NFT metadata.