### PR TITLE
fix(H-D2): store actual pot in fulfilledCommitmentsOf after fulfillment

### DIFF
--- a/contracts/DefifaDeployer.sol
+++ b/contracts/DefifaDeployer.sol
@@ -487,6 +487,9 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
         // Update the ruleset to the final one.
         controller.queueRulesetsOf(_gameId, rulesetConfigs, 'Defifa game has finished.');
 
+        // Update the fulfilled commitments to the actual pot amount.
+        fulfilledCommitmentsOf[_gameId] = _pot;
+
         emit FulfilledCommitments({
             gameId: _gameId,
             pot: _pot,


### PR DESCRIPTION
Was storing sentinel value 1 as a reentrancy guard but never updating to the real amount. currentGamePotOf with _includeCommitments=true would add 1 wei instead of the actual fulfilled amount.