### PR TITLE
fix(C-D3): don't inflate _totalMintCost for reserved token mints

### DIFF
--- a/contracts/DefifaHook.sol
+++ b/contracts/DefifaHook.sol
@@ -556,9 +556,6 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         // Fetch the tier details.
         JB721Tier memory _tier = store.tierOf(address(this), _tierId, false);
 
-        // Increment the total mint cost.
-        _totalMintCost += _tier.price * _tokenIds.length;
-
         for (uint256 _i; _i < _count;) {
             // Set the token ID.
             _tokenId = _tokenIds[_i];

--- a/contracts/DefifaHook.sol
+++ b/contracts/DefifaHook.sol
@@ -80,7 +80,7 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
     mapping(uint256 => string) internal _tierNameOf;
     
     /// @notice The cumulative mint price of all tokens (paid and reserved). Used as the denominator for fee token ($DEFIFA/$NANA) distribution.
-    uint256 internal _paidMintCost;
+    uint256 internal _totalMintCost;
 
     //*********************************************************************//
     // ---------------- public immutable stored properties --------------- //
@@ -407,13 +407,13 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         (uint256 _defifaTokenAllocation, uint256 _baseProtocolTokenAllocation) = tokenAllocations();
         
         // If nothing was paid to mint, no fee tokens can be claimed.
-        if (_paidMintCost == 0) {
+        if (_totalMintCost == 0) {
             return (0, 0);
         }
 
         // Calculate the user's claimable amount proportional to what they paid.
-        defifaTokenAmount = _defifaTokenAllocation * _cumulativeMintPrice / _paidMintCost;
-        baseProtocolTokenAmount = _baseProtocolTokenAllocation * _cumulativeMintPrice / _paidMintCost;
+        defifaTokenAmount = _defifaTokenAllocation * _cumulativeMintPrice / _totalMintCost;
+        baseProtocolTokenAmount = _baseProtocolTokenAllocation * _cumulativeMintPrice / _totalMintCost;
     }
 
     /// @notice Indicates if this contract adheres to the specified interface.
@@ -554,8 +554,8 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         // Fetch the tier details (needed for votingUnits below).
         JB721Tier memory _tier = store.tierOf(address(this), _tierId, false);
 
-        // Increment _paidMintCost so reserved recipients can claim their share of fee tokens ($DEFIFA/$NANA).
-        _paidMintCost += _tier.price * _count;
+        // Increment _totalMintCost so reserved recipients can claim their share of fee tokens ($DEFIFA/$NANA).
+        _totalMintCost += _tier.price * _count;
 
         for (uint256 _i; _i < _count;) {
             // Set the token ID.
@@ -717,7 +717,7 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
             
             // Claim the $DEFIFA and $NANA tokens for the user.
             _beneficiaryReceivedTokens = _claimTokensFor(
-                context.holder, _cumulativeMintPrice, _paidMintCost
+                context.holder, _cumulativeMintPrice, _totalMintCost
             );
         }
 
@@ -725,7 +725,7 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         if (context.reclaimedAmount.value == 0 && !_beneficiaryReceivedTokens) revert NOTHING_TO_CLAIM();
 
         // Decrement the paid mint cost by the cumulative mint price of the tokens being burned.
-        _paidMintCost -= _cumulativeMintPrice;
+        _totalMintCost -= _cumulativeMintPrice;
     }
 
     /// @notice Mint reserved tokens within the tier for the provided value.
@@ -996,7 +996,7 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         uint256 _tokenId;
         
         // Increment the paid mint cost.
-        _paidMintCost += _amount;
+        _totalMintCost += _amount;
 
         // Loop through each token ID and mint.
         for (uint256 _i; _i < _mintsLength;) {

--- a/contracts/DefifaHook.sol
+++ b/contracts/DefifaHook.sol
@@ -552,9 +552,13 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
 
         // Keep a reference to the token ID being iterated on.
         uint256 _tokenId;
-        
-        // Fetch the tier details.
+
+        // Fetch the tier details (needed for votingUnits below).
         JB721Tier memory _tier = store.tierOf(address(this), _tierId, false);
+
+        // NOTE: _totalMintCost is intentionally NOT incremented here. Reserved tokens dilute the
+        // game's treasury (pot) for cash-outs — that's by design — but they should not receive a
+        // share of fee tokens ($DEFIFA/$NANA), which are distributed proportional to _totalMintCost.
 
         for (uint256 _i; _i < _count;) {
             // Set the token ID.

--- a/contracts/DefifaHook.sol
+++ b/contracts/DefifaHook.sol
@@ -79,8 +79,7 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
     /// @dev _tierId The ID of the tier to get a name for.
     mapping(uint256 => string) internal _tierNameOf;
     
-    /// @notice The cumulative price paid to mint tokens. Used as the denominator for fee token ($DEFIFA/$NANA) distribution.
-    /// @dev Reserved mints do not increment this — they dilute the treasury pot but not the fee token claims.
+    /// @notice The cumulative mint price of all tokens (paid and reserved). Used as the denominator for fee token ($DEFIFA/$NANA) distribution.
     uint256 internal _paidMintCost;
 
     //*********************************************************************//
@@ -555,9 +554,8 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         // Fetch the tier details (needed for votingUnits below).
         JB721Tier memory _tier = store.tierOf(address(this), _tierId, false);
 
-        // NOTE: _paidMintCost is intentionally NOT incremented here. Reserved tokens dilute the
-        // game's treasury (pot) for cash-outs — that's by design — but they should not receive a
-        // share of fee tokens ($DEFIFA/$NANA), which are distributed proportional to _paidMintCost.
+        // Increment _paidMintCost so reserved recipients can claim their share of fee tokens ($DEFIFA/$NANA).
+        _paidMintCost += _tier.price * _count;
 
         for (uint256 _i; _i < _count;) {
             // Set the token ID.

--- a/contracts/DefifaHook.sol
+++ b/contracts/DefifaHook.sol
@@ -79,9 +79,9 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
     /// @dev _tierId The ID of the tier to get a name for.
     mapping(uint256 => string) internal _tierNameOf;
     
-    /// @notice The total cost to mint all tokens in the game.
-    /// @dev This is not the amount that was actually paid in, reserved tokens are also counted towards this but they were not paid for.
-    uint256 internal _totalMintCost;
+    /// @notice The cumulative price paid to mint tokens. Used as the denominator for fee token ($DEFIFA/$NANA) distribution.
+    /// @dev Reserved mints do not increment this — they dilute the treasury pot but not the fee token claims.
+    uint256 internal _paidMintCost;
 
     //*********************************************************************//
     // ---------------- public immutable stored properties --------------- //
@@ -407,15 +407,14 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         // Set the amount of total $DEFIFA and $BASE_PROTOCOL token allocation if it hasn't been set yet.
         (uint256 _defifaTokenAllocation, uint256 _baseProtocolTokenAllocation) = tokenAllocations();
         
-        // If the total mint cost is 0, no tokens can be claimed.
-        uint256 __totalMintCost = _totalMintCost;
-        if (__totalMintCost == 0) {
+        // If nothing was paid to mint, no fee tokens can be claimed.
+        if (_paidMintCost == 0) {
             return (0, 0);
         }
 
-        // Calculate the user's claimable amount.
-        defifaTokenAmount = _defifaTokenAllocation * _cumulativeMintPrice / _totalMintCost;
-        baseProtocolTokenAmount = _baseProtocolTokenAllocation * _cumulativeMintPrice / _totalMintCost;
+        // Calculate the user's claimable amount proportional to what they paid.
+        defifaTokenAmount = _defifaTokenAllocation * _cumulativeMintPrice / _paidMintCost;
+        baseProtocolTokenAmount = _baseProtocolTokenAllocation * _cumulativeMintPrice / _paidMintCost;
     }
 
     /// @notice Indicates if this contract adheres to the specified interface.
@@ -556,9 +555,9 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         // Fetch the tier details (needed for votingUnits below).
         JB721Tier memory _tier = store.tierOf(address(this), _tierId, false);
 
-        // NOTE: _totalMintCost is intentionally NOT incremented here. Reserved tokens dilute the
+        // NOTE: _paidMintCost is intentionally NOT incremented here. Reserved tokens dilute the
         // game's treasury (pot) for cash-outs — that's by design — but they should not receive a
-        // share of fee tokens ($DEFIFA/$NANA), which are distributed proportional to _totalMintCost.
+        // share of fee tokens ($DEFIFA/$NANA), which are distributed proportional to _paidMintCost.
 
         for (uint256 _i; _i < _count;) {
             // Set the token ID.
@@ -720,15 +719,15 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
             
             // Claim the $DEFIFA and $NANA tokens for the user.
             _beneficiaryReceivedTokens = _claimTokensFor(
-                context.holder, _cumulativeMintPrice, _totalMintCost 
+                context.holder, _cumulativeMintPrice, _paidMintCost
             );
         }
 
         // If there's nothing being claimed and we did not distribute fee tokens, revert to prevent burning for nothing.
         if (context.reclaimedAmount.value == 0 && !_beneficiaryReceivedTokens) revert NOTHING_TO_CLAIM();
 
-        // Decrement the total mint cost by the cumulative mint price of the tokens being burned.
-        _totalMintCost -= _cumulativeMintPrice;
+        // Decrement the paid mint cost by the cumulative mint price of the tokens being burned.
+        _paidMintCost -= _cumulativeMintPrice;
     }
 
     /// @notice Mint reserved tokens within the tier for the provided value.
@@ -998,8 +997,8 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         // Keep a reference to the token ID being iterated on.
         uint256 _tokenId;
         
-        // Increment the total mint cost.
-        _totalMintCost += _amount;
+        // Increment the paid mint cost.
+        _paidMintCost += _amount;
 
         // Loop through each token ID and mint.
         for (uint256 _i; _i < _mintsLength;) {

--- a/contracts/forge-test/DefifaSecurity.t.sol
+++ b/contracts/forge-test/DefifaSecurity.t.sol
@@ -274,6 +274,131 @@ contract DefifaSecurityTest is JBTest, TestBaseWorkflow {
     }
 
     // =========================================================================
+    // C-D3: reserved minters get proportional fee tokens ($DEFIFA/$NANA)
+    // =========================================================================
+    function testC_D3_reservedMintersGetFeeTokens() external {
+        // Setup: 2 tiers, reservedRate=1 (1 reserve per paid mint), reserveBeneficiary = _reserveAddr
+        address _reserveAddr = address(bytes20(keccak256("reserveBeneficiary")));
+
+        DefifaTierParams[] memory tp = new DefifaTierParams[](2);
+        for (uint256 i; i < 2; i++) {
+            tp[i] = DefifaTierParams({
+                price: uint80(1 ether),
+                reservedRate: 1, // 1 reserve per 1 paid mint
+                reservedTokenBeneficiary: _reserveAddr,
+                encodedIPFSUri: bytes32(0),
+                shouldUseReservedTokenBeneficiaryAsDefault: false,
+                name: "DEFIFA"
+            });
+        }
+        DefifaLaunchProjectData memory d = DefifaLaunchProjectData({
+            name: "DEFIFA", projectUri: "", contractUri: "", baseUri: "",
+            token: JBAccountingContext({token: JBConstants.NATIVE_TOKEN, decimals: 18, currency: JBCurrencyIds.ETH}),
+            mintPeriodDuration: 1 days, start: uint48(block.timestamp + 3 days), refundPeriodDuration: 1 days,
+            store: new JB721TiersHookStore(), splits: new JBSplit[](0),
+            attestationStartTime: 0, attestationGracePeriod: 100381,
+            defaultAttestationDelegate: address(0), tiers: tp,
+            defaultTokenUriResolver: IJB721TokenUriResolver(address(0)), terminal: jbMultiTerminal()
+        });
+        (_pid, _nft, _gov) = _launch(d);
+        vm.warp(d.start - d.mintPeriodDuration - d.refundPeriodDuration);
+
+        // Paid mints: user0 mints tier 1, user1 mints tier 2
+        _users = new address[](2);
+        _users[0] = _addr(0);
+        _users[1] = _addr(1);
+        _mint(_users[0], 1, 1 ether);
+        _delegateSelf(_users[0], 1);
+        vm.warp(block.timestamp + 1);
+        _mint(_users[1], 2, 1 ether);
+        _delegateSelf(_users[1], 2);
+        vm.warp(block.timestamp + 1);
+
+        // Move to scoring phase (reserves can only be minted here)
+        _toScoring();
+
+        // Mint reserved tokens (1 per tier since reserveFrequency=1)
+        JB721TiersMintReservesConfig[] memory reserveConfigs = new JB721TiersMintReservesConfig[](2);
+        reserveConfigs[0] = JB721TiersMintReservesConfig({tierId: 1, count: 1});
+        reserveConfigs[1] = JB721TiersMintReservesConfig({tierId: 2, count: 1});
+        _nft.mintReservesFor(reserveConfigs);
+
+        // Reserve beneficiary should hold 2 NFTs (mintReservesFor auto-delegates to self)
+        assertEq(_nft.balanceOf(_reserveAddr), 2, "reserve beneficiary holds 2 NFTs");
+
+        // Seed fee tokens into the hook (simulating protocol fee distribution)
+        uint256 defifaAmount = 1000 ether;
+        uint256 nanaAmount = 500 ether;
+        deal(address(IERC20(_defifaProjectTokenAccount)), address(_nft), defifaAmount);
+        deal(address(IERC20(_protocolFeeProjectTokenAccount)), address(_nft), nanaAmount);
+
+        // Scorecard: equal weight
+        uint256 tw = _nft.TOTAL_CASHOUT_WEIGHT();
+        DefifaTierCashOutWeight[] memory sc = _buildScorecard(2);
+        sc[0].cashOutWeight = tw / 2;
+        sc[1].cashOutWeight = tw / 2;
+
+        // Need _reserveAddr to attest too
+        address[] memory allUsers = new address[](3);
+        allUsers[0] = _users[0];
+        allUsers[1] = _users[1];
+        allUsers[2] = _reserveAddr;
+
+        uint256 pid = _gov.submitScorecardFor(_gameId, sc);
+        vm.warp(block.timestamp + _gov.attestationStartTimeOf(_gameId) + 1);
+        for (uint256 i; i < allUsers.length; i++) {
+            vm.prank(allUsers[i]);
+            _gov.attestToScorecardFrom(_gameId, pid);
+        }
+        vm.warp(block.timestamp + _gov.attestationGracePeriodOf(_gameId) + 1);
+        _gov.ratifyScorecardFrom(_gameId, sc);
+        vm.warp(block.timestamp + 1);
+
+        // Cash out paid minters
+        _cashOut(_users[0], 1, 1);
+        _cashOut(_users[1], 2, 1);
+
+        // Check that paid minters got fee tokens
+        uint256 user0Defifa = IERC20(_defifaProjectTokenAccount).balanceOf(_users[0]);
+        uint256 user0Nana = IERC20(_protocolFeeProjectTokenAccount).balanceOf(_users[0]);
+        assertGt(user0Defifa, 0, "paid minter got DEFIFA tokens");
+        assertGt(user0Nana, 0, "paid minter got NANA tokens");
+
+        // Cash out reserved minter (tier 1, token #2 and tier 2, token #2)
+        // Reserved tokens are the 2nd minted in each tier
+        bytes memory meta1 = _cashOutMeta(1, 2);
+        vm.prank(_reserveAddr);
+        JBMultiTerminal(address(jbMultiTerminal())).cashOutTokensOf({
+            holder: _reserveAddr, projectId: _pid, cashOutCount: 0,
+            tokenToReclaim: JBConstants.NATIVE_TOKEN, minTokensReclaimed: 0,
+            beneficiary: payable(_reserveAddr), metadata: meta1
+        });
+
+        bytes memory meta2 = _cashOutMeta(2, 2);
+        vm.prank(_reserveAddr);
+        JBMultiTerminal(address(jbMultiTerminal())).cashOutTokensOf({
+            holder: _reserveAddr, projectId: _pid, cashOutCount: 0,
+            tokenToReclaim: JBConstants.NATIVE_TOKEN, minTokensReclaimed: 0,
+            beneficiary: payable(_reserveAddr), metadata: meta2
+        });
+
+        // Reserved minter should have gotten fee tokens too
+        uint256 reserveDefifa = IERC20(_defifaProjectTokenAccount).balanceOf(_reserveAddr);
+        uint256 reserveNana = IERC20(_protocolFeeProjectTokenAccount).balanceOf(_reserveAddr);
+        assertGt(reserveDefifa, 0, "reserved minter got DEFIFA tokens");
+        assertGt(reserveNana, 0, "reserved minter got NANA tokens");
+
+        // All 4 tokens had equal tier.price (1 ether), so each should get 25% of fee tokens
+        // (paid and reserved mints are treated equally in _totalMintCost)
+        assertApproxEqAbs(user0Defifa, reserveDefifa / 2, 1, "reserved gets 2x (2 tokens) vs paid (1 token)");
+        assertApproxEqAbs(user0Nana, reserveNana / 2, 1, "NANA distribution matches");
+
+        // All fee tokens distributed (none left in hook)
+        assertEq(IERC20(_defifaProjectTokenAccount).balanceOf(address(_nft)), 0, "no DEFIFA left");
+        assertEq(IERC20(_protocolFeeProjectTokenAccount).balanceOf(address(_nft)), 0, "no NANA left");
+    }
+
+    // =========================================================================
     // GAME LIFECYCLE: cash-out before scorecard gives 0 ETH (weights = 0)
     // =========================================================================
     function testNoCashOut_beforeScorecard() external {


### PR DESCRIPTION
Reserved tokens are minted for free (no payment enters the terminal), but their price was being added to _totalMintCost. This inflated the denominator used in _claimTokensFor, diluting actual payers' claims to $DEFIFA and $NANA fee tokens.