### PR TITLE
fix(C-D1): prevent duplicate tier IDs in scorecard weight setting

### DIFF
--- a/contracts/DefifaHook.sol
+++ b/contracts/DefifaHook.sol
@@ -618,7 +618,14 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         // Keep a reference to the tier being iterated on.
         JB721Tier memory _tier;
 
+        // Keep a reference to the last tier ID to enforce ascending order (no duplicates).
+        uint256 _lastTierId;
+
         for (uint256 _i; _i < _numberOfTierWeights;) {
+            // Enforce strict ascending order to prevent duplicate tier IDs.
+            if (_tierWeights[_i].id <= _lastTierId && _i != 0) revert BAD_TIER_ORDER();
+            _lastTierId = _tierWeights[_i].id;
+
             // Get the tier.
             _tier = store.tierOf(address(this), _tierWeights[_i].id, false);
 


### PR DESCRIPTION
Add strict ascending order check on tier IDs in setTierCashOutWeightsTo. Duplicate tier IDs would overwrite stored weights while inflating the cumulative weight tracker, allowing a scorecard to pass validation while assigning less total weight than claimed — permanently locking funds in the game pot.