### PR TITLE
Fix NANA protocol fee to 2.5%

### DIFF
--- a/contracts/DefifaDeployer.sol
+++ b/contracts/DefifaDeployer.sol
@@ -106,8 +106,8 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
     IJBAddressRegistry public immutable registry;
 
     /// @notice The divisor that describes the protocol fee that should be taken.
-    /// @dev This is equal to 100 divided by the fee percent (e.g. 20 = 5% fee).
-    uint256 public constant override BASE_PROTOCOL_FEE_DIVISOR = 20;
+    /// @dev This is equal to 100 divided by the fee percent (e.g. 40 = 2.5% fee).
+    uint256 public constant override BASE_PROTOCOL_FEE_DIVISOR = 40;
 
     /// @notice The divisor that describes the Defifa fee that should be taken.
     /// @dev This is equal to 100 divided by the fee percent (e.g. 20 = 5% fee).

--- a/contracts/forge-test/DefifaFeeAccounting.t.sol
+++ b/contracts/forge-test/DefifaFeeAccounting.t.sol
@@ -128,7 +128,7 @@ contract DefifaFeeAccountingTest is JBTest, TestBaseWorkflow {
 
     // -----------------------------------------------------------------------
     // Test 1: Fee accounting with default splits (no user splits)
-    // defifa = 5%, nana = 5%, total commitment = 10%
+    // defifa = 5%, nana = 2.5%, total commitment = 7.5%
     // -----------------------------------------------------------------------
     function testFeeAccounting_defaultSplits() external {
         uint8 nTiers = 4;
@@ -145,11 +145,11 @@ contract DefifaFeeAccountingTest is JBTest, TestBaseWorkflow {
         );
         assertEq(potBefore, nTiers * 1 ether, "pot should be nTiers ETH");
 
-        // Expected fee: pot * (5% + 5%) = pot * 10%
+        // Expected fee: pot * (5% + 2.5%) = pot * 7.5%
         // DEFIFA_FEE_DIVISOR = 20 -> 1_000_000_000 / 20 = 50_000_000 (5%)
-        // BASE_PROTOCOL_FEE_DIVISOR = 20 -> 1_000_000_000 / 20 = 50_000_000 (5%)
-        // totalAbsolutePercent = 100_000_000
-        uint256 expectedFee = (potBefore * 100_000_000) / JBConstants.SPLITS_TOTAL_PERCENT;
+        // BASE_PROTOCOL_FEE_DIVISOR = 40 -> 1_000_000_000 / 40 = 25_000_000 (2.5%)
+        // totalAbsolutePercent = 75_000_000
+        uint256 expectedFee = (potBefore * 75_000_000) / JBConstants.SPLITS_TOTAL_PERCENT;
         uint256 expectedSurplus = potBefore - expectedFee;
 
         // Advance through lifecycle and ratify scorecard.
@@ -191,7 +191,7 @@ contract DefifaFeeAccountingTest is JBTest, TestBaseWorkflow {
         _ratifyEvenScorecard(users, _nft, _governor, projectId, nTiers);
         vm.warp(block.timestamp + 1);
 
-        uint256 expectedFee = (potBefore * 100_000_000) / JBConstants.SPLITS_TOTAL_PERCENT;
+        uint256 expectedFee = (potBefore * 75_000_000) / JBConstants.SPLITS_TOTAL_PERCENT;
         uint256 surplus = potBefore - expectedFee;
 
         // Each user cashes out their NFT.
@@ -275,8 +275,8 @@ contract DefifaFeeAccountingTest is JBTest, TestBaseWorkflow {
             address(jbMultiTerminal()), projectId, JBConstants.NATIVE_TOKEN
         );
 
-        // totalAbsolutePercent = 50_000_000 + 50_000_000 + 100_000_000 = 200_000_000 (20%)
-        uint256 expectedFee = (potBefore * 200_000_000) / JBConstants.SPLITS_TOTAL_PERCENT;
+        // totalAbsolutePercent = 25_000_000 + 50_000_000 + 100_000_000 = 175_000_000 (17.5%)
+        uint256 expectedFee = (potBefore * 175_000_000) / JBConstants.SPLITS_TOTAL_PERCENT;
         uint256 expectedSurplus = potBefore - expectedFee;
 
         // Ratify scorecard (triggers fulfillment).
@@ -322,8 +322,8 @@ contract DefifaFeeAccountingTest is JBTest, TestBaseWorkflow {
         _ratifyEvenScorecard(users, _nft, _governor, projectId, nTiers);
         vm.warp(block.timestamp + 1);
 
-        // 20% fee (5% nana + 5% defifa + 10% user)
-        uint256 expectedFee = (potBefore * 200_000_000) / JBConstants.SPLITS_TOTAL_PERCENT;
+        // 17.5% fee (2.5% nana + 5% defifa + 10% user)
+        uint256 expectedFee = (potBefore * 175_000_000) / JBConstants.SPLITS_TOTAL_PERCENT;
         uint256 surplus = potBefore - expectedFee;
 
         // Cash out all tiers.
@@ -352,7 +352,7 @@ contract DefifaFeeAccountingTest is JBTest, TestBaseWorkflow {
         assertApproxEqRel(totalCashedOut, surplus, 0.001 ether, "cash-out with user splits should equal surplus after 20% fee");
 
         // Verify that surplus is meaningfully less than with no user splits.
-        uint256 surplusWithoutUserSplits = potBefore - (potBefore * 100_000_000) / JBConstants.SPLITS_TOTAL_PERCENT;
+        uint256 surplusWithoutUserSplits = potBefore - (potBefore * 75_000_000) / JBConstants.SPLITS_TOTAL_PERCENT;
         assertTrue(surplus < surplusWithoutUserSplits, "user splits should reduce available surplus");
     }
 


### PR DESCRIPTION
## Summary
- `BASE_PROTOCOL_FEE_DIVISOR` was 20 (5%), should be 40 (2.5%)
- Default total commitment: 2.5% nana + 5% defifa = 7.5% (was 10%)
- Updated all fee accounting test expectations

## Test plan
- [x] All 50 tests pass with corrected fee percentages
- [x] Fee accounting tests verify exact surplus amounts
- [x] Cash-out tests confirm remainder backs scorecard value

🤖 Generated with [Claude Code](https://claude.com/claude-code)