### PR TITLE
chore: standardize slither config, convert positional args to named params

### DIFF
--- a/slither-ci.config.json
+++ b/slither-ci.config.json
@@ -1,6 +1,10 @@
 {
     "detectors_to_exclude": "timestamp,uninitialized-local,naming-convention,solc-version,shadowing-local",
     "exclude_informational": true,
+    "exclude_low": false,
+    "exclude_medium": false,
+    "exclude_high": false,
+    "disable_color": false,
     "filter_paths": "(mocks/|test/|node_modules/)",
     "legacy_ast": false
 }

--- a/src/DefifaDeployer.sol
+++ b/src/DefifaDeployer.sol
@@ -667,8 +667,8 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
         accountingContexts[0] = launchProjectData.token;
 
         // Build the terminal configuration for the Defifa project.
-        JBTerminalConfig[] memory terminalConfigs = new JBTerminalConfig[](1);
-        terminalConfigs[0] =
+        JBTerminalConfig[] memory terminalConfigurations = new JBTerminalConfig[](1);
+        terminalConfigurations[0] =
             JBTerminalConfig({terminal: launchProjectData.terminal, accountingContextsToAccept: accountingContexts});
 
         // Build the rulesets that this Defifa game will go through.
@@ -823,7 +823,7 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
             owner: address(this),
             projectUri: launchProjectData.projectUri,
             rulesetConfigurations: rulesetConfigs,
-            terminalConfigurations: terminalConfigs,
+            terminalConfigurations: terminalConfigurations,
             memo: "Launching Defifa game."
         });
     }

--- a/src/DefifaDeployer.sol
+++ b/src/DefifaDeployer.sol
@@ -185,13 +185,18 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
         address _token = _opsOf[gameId].token;
 
         // Get a reference to the terminal.
-        IJBTerminal _terminal = controller.DIRECTORY().primaryTerminalOf(gameId, _token);
+        IJBTerminal _terminal = controller.DIRECTORY().primaryTerminalOf({projectId: gameId, token: _token});
 
         // Get the accounting context for the project.
-        JBAccountingContext memory _context = _terminal.accountingContextForTokenOf(gameId, _token);
+        JBAccountingContext memory _context =
+            _terminal.accountingContextForTokenOf({projectId: gameId, token: _token});
 
         // Get the current balance.
-        uint256 _pot = IJBMultiTerminal(address(_terminal)).STORE().balanceOf(address(_terminal), gameId, _token);
+        uint256 _pot = IJBMultiTerminal(address(_terminal)).STORE().balanceOf({
+            terminal: address(_terminal),
+            projectId: gameId,
+            token: _token
+        });
 
         // Add any fulfilled commitments.
         if (includeCommitments) _pot += fulfilledCommitmentsOf[gameId];
@@ -245,9 +250,12 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
         // Check minimum participation threshold: if the treasury balance is below the threshold, the game is
         // NO_CONTEST.
         if (_ops.minParticipation > 0) {
-            IJBTerminal _terminal = controller.DIRECTORY().primaryTerminalOf(gameId, _ops.token);
-            uint256 _balance =
-                IJBMultiTerminal(address(_terminal)).STORE().balanceOf(address(_terminal), gameId, _ops.token);
+            IJBTerminal _terminal = controller.DIRECTORY().primaryTerminalOf({projectId: gameId, token: _ops.token});
+            uint256 _balance = IJBMultiTerminal(address(_terminal)).STORE().balanceOf({
+                terminal: address(_terminal),
+                projectId: gameId,
+                token: _ops.token
+            });
             if (_balance < _ops.minParticipation) return DefifaGamePhase.NO_CONTEST;
         }
 
@@ -371,7 +379,11 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
                 _groupedSplits[0] = JBSplitGroup({groupId: splitGroup, splits: _splits});
 
                 // This contract must have SET_SPLIT_GROUPS permission from the defifa project owner.
-                controller.setSplitGroupsOf(defifaProjectId, gameId, _groupedSplits);
+                controller.setSplitGroupsOf({
+                    projectId: defifaProjectId,
+                    rulesetId: gameId,
+                    splitGroups: _groupedSplits
+                });
             }
         }
 
@@ -453,7 +465,11 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
         });
 
         // Launch the Juicebox project.
-        uint256 _actualGameId = _launchGame(launchProjectData, gameId, address(_hook));
+        uint256 _actualGameId = _launchGame({
+            launchProjectData: launchProjectData,
+            _gameId: gameId,
+            _dataHook: address(_hook)
+        });
 
         // Revert if the game ID does not match (e.g. front-run by another project creation).
         if (gameId != _actualGameId) revert DefifaDeployer_InvalidGameConfiguration();
@@ -469,7 +485,7 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
         _hook.transferOwnership(address(governor));
 
         // Add the hook to the registry, contract nonce starts at 1
-        registry.registerAddress(address(this), _currentNonce);
+        registry.registerAddress({deployer: address(this), nonce: _currentNonce});
 
         emit LaunchGame(gameId, _hook, governor, _uriResolver, msg.sender);
     }
@@ -491,10 +507,10 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
         // Get the game token and the terminal.
         address _token = _opsOf[gameId].token;
         IJBMultiTerminal _terminal =
-            IJBMultiTerminal(address(controller.DIRECTORY().primaryTerminalOf(gameId, _token)));
+            IJBMultiTerminal(address(controller.DIRECTORY().primaryTerminalOf({projectId: gameId, token: _token})));
 
         // Get the current pot and store it. This also prevents re-entrance since the check above will return early.
-        uint256 _pot = _terminal.STORE().balanceOf(address(_terminal), gameId, _token);
+        uint256 _pot = _terminal.STORE().balanceOf({terminal: address(_terminal), projectId: gameId, token: _token});
         if (_pot == 0) revert DefifaDeployer_NothingToFulfill();
 
         // Compute the fee amount based on the total absolute split percent stored at game creation.
@@ -553,7 +569,11 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
         });
 
         // Update the ruleset to the final one.
-        controller.queueRulesetsOf(gameId, rulesetConfigs, "Defifa game has finished.");
+        controller.queueRulesetsOf({
+            projectId: gameId,
+            rulesetConfigurations: rulesetConfigs,
+            memo: "Defifa game has finished."
+        });
 
         emit FulfilledCommitments({gameId: gameId, pot: _pot, caller: msg.sender});
     }
@@ -616,7 +636,11 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
         });
 
         // Queue the no-contest refund ruleset.
-        controller.queueRulesetsOf(gameId, rulesetConfigs, "Defifa game: no contest.");
+        controller.queueRulesetsOf({
+            projectId: gameId,
+            rulesetConfigurations: rulesetConfigs,
+            memo: "Defifa game: no contest."
+        });
 
         emit QueuedNoContest(gameId, msg.sender);
     }
@@ -785,7 +809,12 @@ contract DefifaDeployer is IDefifaDeployer, IDefifaGamePhaseReporter, IDefifaGam
                     )
                 )
             }),
-            splitGroups: _buildSplits(_gameId, _dataHook, launchProjectData.token.token, launchProjectData.splits),
+            splitGroups: _buildSplits({
+                _gameId: _gameId,
+                _dataHook: _dataHook,
+                _token: launchProjectData.token.token,
+                _initialSplits: launchProjectData.splits
+            }),
             fundAccessLimitGroups: fundAccessConstraints
         });
 

--- a/src/DefifaGovernor.sol
+++ b/src/DefifaGovernor.sol
@@ -116,7 +116,7 @@ contract DefifaGovernor is Ownable, IDefifaGovernor {
         override
         returns (uint256)
     {
-        return _hashScorecardOf(gameHook, _buildScorecardCalldataFor(tierWeights));
+        return _hashScorecardOf({_gameHook: gameHook, _calldata: _buildScorecardCalldataFor(tierWeights)});
     }
 
     //*********************************************************************//
@@ -246,8 +246,8 @@ contract DefifaGovernor is Ownable, IDefifaGovernor {
             uint256 _tierId = _i + 1;
 
             // Get this account's attestation units within the tier (snapshot at _timestamp).
-            uint256 _tierAttestationUnitsForAccount =
-                IDefifaHook(_metadata.dataHook).getPastTierAttestationUnitsOf(_account, _tierId, _timestamp);
+            uint256 _tierAttestationUnitsForAccount = IDefifaHook(_metadata.dataHook)
+                .getPastTierAttestationUnitsOf({account: _account, tier: _tierId, timestamp: _timestamp});
 
             // Scale the account's share of the tier to MAX_ATTESTATION_POWER_TIER.
             // e.g. holding 3 of 10 tokens → 3/10 * MAX_ATTESTATION_POWER_TIER attestation power from this tier.
@@ -256,7 +256,10 @@ contract DefifaGovernor is Ownable, IDefifaGovernor {
                     attestationPower += mulDiv(
                         MAX_ATTESTATION_POWER_TIER,
                         _tierAttestationUnitsForAccount,
-                        IDefifaHook(_metadata.dataHook).getPastTierTotalAttestationUnitsOf(_tierId, _timestamp)
+                        IDefifaHook(_metadata.dataHook).getPastTierTotalAttestationUnitsOf({
+                            tier: _tierId,
+                            timestamp: _timestamp
+                        })
                     );
                 }
             }
@@ -352,7 +355,7 @@ contract DefifaGovernor is Ownable, IDefifaGovernor {
         }
 
         // Hash the scorecard.
-        scorecardId = _hashScorecardOf(_metadata.dataHook, _buildScorecardCalldataFor(_tierWeights));
+        scorecardId = _hashScorecardOf({_gameHook: _metadata.dataHook, _calldata: _buildScorecardCalldataFor(_tierWeights)});
 
         // Store the scorecard
         DefifaScorecard storage _scorecard = _scorecardOf[_gameId][scorecardId];
@@ -396,7 +399,7 @@ contract DefifaGovernor is Ownable, IDefifaGovernor {
         DefifaScorecard storage _scorecard = _scorecardOf[gameId][scorecardId];
 
         // Keep a reference to the scorecard state.
-        DefifaScorecardState _state = stateOf(gameId, scorecardId);
+        DefifaScorecardState _state = stateOf({gameId: gameId, scorecardId: scorecardId});
 
         if (_state != DefifaScorecardState.ACTIVE && _state != DefifaScorecardState.SUCCEEDED) {
             revert DefifaGovernor_NotAllowed();
@@ -409,7 +412,11 @@ contract DefifaGovernor is Ownable, IDefifaGovernor {
         if (_attestations.hasAttested[msg.sender]) revert DefifaGovernor_AlreadyAttested();
 
         // Get a reference to the attestation weight.
-        weight = getAttestationWeight(gameId, msg.sender, _scorecard.attestationsBegin);
+        weight = getAttestationWeight({
+            _gameId: gameId,
+            _account: msg.sender,
+            _timestamp: _scorecard.attestationsBegin
+        });
 
         // Increase the attestation count.
         _attestations.count += weight;
@@ -442,17 +449,19 @@ contract DefifaGovernor is Ownable, IDefifaGovernor {
         bytes memory _calldata = _buildScorecardCalldataFor(tierWeights);
 
         // Attempt to execute the proposal.
-        scorecardId = _hashScorecardOf(_metadata.dataHook, _calldata);
+        scorecardId = _hashScorecardOf({_gameHook: _metadata.dataHook, _calldata: _calldata});
 
         // Make sure the proposal being ratified has succeeded.
-        if (stateOf(gameId, scorecardId) != DefifaScorecardState.SUCCEEDED) revert DefifaGovernor_NotAllowed();
+        if (stateOf({gameId: gameId, scorecardId: scorecardId}) != DefifaScorecardState.SUCCEEDED) {
+            revert DefifaGovernor_NotAllowed();
+        }
 
         // Set the ratified scorecard.
         ratifiedScorecardIdOf[gameId] = scorecardId;
 
         // Execute the scorecard via low-level call since the governor is the delegate's owner.
         (bool success, bytes memory returndata) = _metadata.dataHook.call(_calldata);
-        Address.verifyCallResult(success, returndata);
+        Address.verifyCallResult({success: success, returndata: returndata});
 
         // Fulfill any commitments for the game.
         IDefifaDeployer(controller.PROJECTS().ownerOf(gameId)).fulfillCommitmentsOf(gameId);

--- a/src/DefifaHook.sol
+++ b/src/DefifaHook.sol
@@ -261,22 +261,32 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         override
         returns (uint256 cumulativeWeight)
     {
-        cumulativeWeight = DefifaHookLib.computeCashOutWeightBatch(
-            tokenIds, store, address(this), _tierCashOutWeights, tokensRedeemedFrom
-        );
+        cumulativeWeight = DefifaHookLib.computeCashOutWeightBatch({
+            tokenIds: tokenIds,
+            _store: store,
+            hook: address(this),
+            tierCashOutWeights: _tierCashOutWeights,
+            tokensRedeemedFrom: tokensRedeemedFrom
+        });
     }
 
     /// @notice The weight the given token ID has in cashOuts.
     /// @param tokenId The ID of the token to get the cashOut weight of.
     /// @return The weight.
     function cashOutWeightOf(uint256 tokenId) public view override returns (uint256) {
-        return DefifaHookLib.computeCashOutWeight(tokenId, store, address(this), _tierCashOutWeights, tokensRedeemedFrom);
+        return DefifaHookLib.computeCashOutWeight({
+            tokenId: tokenId,
+            _store: store,
+            hook: address(this),
+            tierCashOutWeights: _tierCashOutWeights,
+            tokensRedeemedFrom: tokensRedeemedFrom
+        });
     }
 
     /// @notice The amount of tokens of a tier that are currently in circulation.
     /// @param tierId The ID of the tier to get the current supply of.
     function currentSupplyOfTier(uint256 tierId) public view returns (uint256) {
-        return DefifaHookLib.computeCurrentSupply(store, address(this), tierId);
+        return DefifaHookLib.computeCurrentSupply({_store: store, hook: address(this), tierId: tierId});
     }
 
     /// @notice The combined cash out weight of all outstanding NFTs.
@@ -343,21 +353,24 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         DefifaGamePhase _gamePhase = gamePhaseReporter.currentGamePhaseOf(context.projectId);
 
         // Calculate the amount paid to mint the tokens that are being burned.
-        uint256 _cumulativeMintPrice =
-            DefifaHookLib.computeCumulativeMintPrice(decodedTokenIds, store, address(this));
+        uint256 _cumulativeMintPrice = DefifaHookLib.computeCumulativeMintPrice({
+            tokenIds: decodedTokenIds,
+            _store: store,
+            hook: address(this)
+        });
 
         // Use this contract as the only cash out hook.
         hookSpecifications = new JBCashOutHookSpecification[](1);
         hookSpecifications[0] = JBCashOutHookSpecification(this, 0, abi.encode(_cumulativeMintPrice));
 
         // Compute the cash out count based on the game phase.
-        cashOutCount = DefifaHookLib.computeCashOutCount(
-            _gamePhase,
-            _cumulativeMintPrice,
-            context.surplus.value,
-            amountRedeemed,
-            cashOutWeightOf(decodedTokenIds, context)
-        );
+        cashOutCount = DefifaHookLib.computeCashOutCount({
+            gamePhase: _gamePhase,
+            cumulativeMintPrice: _cumulativeMintPrice,
+            surplusValue: context.surplus.value,
+            _amountRedeemed: amountRedeemed,
+            cumulativeCashOutWeight: cashOutWeightOf(decodedTokenIds, context)
+        });
 
         // Use the surplus as the total supply.
         totalSupply = context.surplus.value;
@@ -378,14 +391,14 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         // If the game isn't complete, we do not have any tokens to claim.
         if (gamePhaseReporter.currentGamePhaseOf(PROJECT_ID) != DefifaGamePhase.COMPLETE) return (0, 0);
 
-        return DefifaHookLib.computeTokensClaim(
-            tokenIds,
-            store,
-            address(this),
-            _totalMintCost,
-            defifaToken.balanceOf(address(this)),
-            baseProtocolToken.balanceOf(address(this))
-        );
+        return DefifaHookLib.computeTokensClaim({
+            tokenIds: tokenIds,
+            _store: store,
+            hook: address(this),
+            totalMintCost: _totalMintCost,
+            defifaBalance: defifaToken.balanceOf(address(this)),
+            baseProtocolBalance: baseProtocolToken.balanceOf(address(this))
+        });
     }
 
     /// @notice Indicates if this contract adheres to the specified interface.
@@ -509,28 +522,30 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
             )) revert DefifaHook_ReservedTokenMintingPaused();
 
         // Keep a reference to the reserved token beneficiary.
-        address _reservedTokenBeneficiary = store.reserveBeneficiaryOf(address(this), tierId);
+        address _reservedTokenBeneficiary = store.reserveBeneficiaryOf({hook: address(this), tierId: tierId});
 
         // Get a reference to the old delegate.
         address _oldDelegate = _tierDelegation[_reservedTokenBeneficiary][tierId];
 
         // Set the delegate as the beneficiary if the beneficiary hasn't already set a delegate.
         if (_oldDelegate == address(0)) {
-            _delegateTier(
-                _reservedTokenBeneficiary,
-                defaultAttestationDelegate != address(0) ? defaultAttestationDelegate : _reservedTokenBeneficiary,
-                tierId
-            );
+            _delegateTier({
+                _account: _reservedTokenBeneficiary,
+                _delegatee: defaultAttestationDelegate != address(0)
+                    ? defaultAttestationDelegate
+                    : _reservedTokenBeneficiary,
+                _tierId: tierId
+            });
         }
 
         // Record the minted reserves for the tier.
-        uint256[] memory _tokenIds = store.recordMintReservesFor(tierId, count);
+        uint256[] memory _tokenIds = store.recordMintReservesFor({tierId: tierId, count: count});
 
         // Keep a reference to the token ID being iterated on.
         uint256 _tokenId;
 
         // Fetch the tier details (needed for votingUnits below).
-        JB721Tier memory _tier = store.tierOf(address(this), tierId, false);
+        JB721Tier memory _tier = store.tierOf({hook: address(this), id: tierId, includeResolvedUri: false});
 
         // Increment _totalMintCost so reserved recipients can claim their share of fee tokens ($DEFIFA/$NANA).
         _totalMintCost += _tier.price * count;
@@ -550,9 +565,12 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         }
 
         // Transfer the attestation units to the delegate.
-        _transferTierAttestationUnits(
-            address(0), _reservedTokenBeneficiary, tierId, _tier.votingUnits * _tokenIds.length
-        );
+        _transferTierAttestationUnits({
+            _from: address(0),
+            _to: _reservedTokenBeneficiary,
+            _tierId: tierId,
+            _amount: _tier.votingUnits * _tokenIds.length
+        });
     }
 
     //*********************************************************************//
@@ -580,7 +598,8 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         }
 
         // Validate weights and build the array. Reverts on invalid input.
-        _tierCashOutWeights = DefifaHookLib.validateAndBuildWeights(tierWeights, store, address(this));
+        _tierCashOutWeights =
+            DefifaHookLib.validateAndBuildWeights({tierWeights: tierWeights, _store: store, hook: address(this)});
 
         // Mark the cashOut weight as set.
         cashOutWeightIsSet = true;
@@ -602,7 +621,8 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         // Make sure the caller is a terminal of the project, and that the call is being made on behalf of an
         // interaction with the correct project.
         if (
-            msg.value != 0 || !DIRECTORY.isTerminalOf(PROJECT_ID, IJBTerminal(msg.sender))
+            msg.value != 0
+                || !DIRECTORY.isTerminalOf({projectId: PROJECT_ID, terminal: IJBTerminal(msg.sender)})
                 || context.projectId != PROJECT_ID
         ) revert JB721Hook_InvalidCashOut();
 
@@ -659,7 +679,11 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
             amountRedeemed += context.reclaimedAmount.value;
 
             // Claim the $DEFIFA and $NANA tokens for the user.
-            _beneficiaryReceivedTokens = _claimTokensFor(context.holder, _cumulativeMintPrice, _totalMintCost);
+            _beneficiaryReceivedTokens = _claimTokensFor({
+                _beneficiary: context.holder,
+                shareToBeneficiary: _cumulativeMintPrice,
+                outOfTotal: _totalMintCost
+            });
         }
 
         // If there's nothing being claimed and we did not distribute fee tokens, revert to prevent burning for nothing.
@@ -709,7 +733,7 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
             // Make sure a delegate is specified.
             if (_data.delegatee == address(0)) revert DefifaHook_DelegateAddressZero();
 
-            _delegateTier(msg.sender, _data.delegatee, _data.tierId);
+            _delegateTier({_account: msg.sender, _delegatee: _data.delegatee, _tierId: _data.tierId});
 
             unchecked {
                 ++_i;
@@ -726,7 +750,7 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
             revert DefifaHook_DelegateChangesUnavailableInThisPhase();
         }
 
-        _delegateTier(msg.sender, delegatee, tierId);
+        _delegateTier({_account: msg.sender, _delegatee: delegatee, _tierId: tierId});
     }
 
     //*********************************************************************//
@@ -758,7 +782,11 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
 
         // Compute attestation units per unique tier (validates ascending order, reverts on bad order).
         (uint256[] memory _tierIds, uint256[] memory _attestationAmounts, uint256 _uniqueTierCount) =
-            DefifaHookLib.computeAttestationUnits(_tierIdsToMint, store, address(this));
+            DefifaHookLib.computeAttestationUnits({
+                _tierIdsToMint: _tierIdsToMint,
+                _store: store,
+                hook: address(this)
+            });
 
         // Apply attestation units for each unique tier.
         for (uint256 _i; _i < _uniqueTierCount;) {
@@ -771,11 +799,16 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
             if (_attestationDelegate != address(0) || _oldDelegate != address(0)) {
                 // Switch delegates if needed.
                 if (_attestationDelegate != address(0) && _attestationDelegate != _oldDelegate) {
-                    _delegateTier(context.payer, _attestationDelegate, _tierId);
+                    _delegateTier({_account: context.payer, _delegatee: _attestationDelegate, _tierId: _tierId});
                 }
 
                 // Transfer the attestation units.
-                _transferTierAttestationUnits(address(0), context.payer, _tierId, _attestationAmounts[_i]);
+                _transferTierAttestationUnits({
+                    _from: address(0),
+                    _to: context.payer,
+                    _tierId: _tierId,
+                    _amount: _attestationAmounts[_i]
+                });
             }
 
             unchecked {
@@ -784,7 +817,11 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         }
 
         // Mint tiers if they were specified.
-        uint256 _leftoverAmount = _mintAll(context.amount.value, _tierIdsToMint, context.beneficiary);
+        uint256 _leftoverAmount = _mintAll({
+            _amount: context.amount.value,
+            _mintTierIds: _tierIdsToMint,
+            _beneficiary: context.beneficiary
+        });
 
         // Make sure the buyer isn't overspending.
         if (_leftoverAmount != 0) revert DefifaHook_Overspending();
@@ -795,7 +832,7 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
     /// @param _tierId The ID of the tier to get attestation units for.
     /// @return The attestation units.
     function _getTierAttestationUnits(address _account, uint256 _tierId) internal view virtual returns (uint256) {
-        return store.tierVotingUnitsOf(address(this), _account, _tierId);
+        return store.tierVotingUnitsOf({hook: address(this), account: _account, tierId: _tierId});
     }
 
     /// @notice Delegate all attestation units for the specified tier.
@@ -812,7 +849,12 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         emit DelegateChanged(_account, _oldDelegate, _delegatee);
 
         // Move the attestations.
-        _moveTierDelegateAttestations(_oldDelegate, _delegatee, _tierId, _getTierAttestationUnits(_account, _tierId));
+        _moveTierDelegateAttestations({
+            _from: _oldDelegate,
+            _to: _delegatee,
+            _tierId: _tierId,
+            _amount: _getTierAttestationUnits({_account: _account, _tierId: _tierId})
+        });
     }
 
     /// @notice Transfers, mints, or burns tier attestation units. To register a mint, `_from` should be zero. To
@@ -846,7 +888,12 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         }
 
         // Move delegated attestations.
-        _moveTierDelegateAttestations(_tierDelegation[_from][_tierId], _tierDelegation[_to][_tierId], _tierId, _amount);
+        _moveTierDelegateAttestations({
+            _from: _tierDelegation[_from][_tierId],
+            _to: _tierDelegation[_to][_tierId],
+            _tierId: _tierId,
+            _amount: _amount
+        });
     }
 
     /// @notice Moves delegated tier attestations from one delegate to another.
@@ -903,11 +950,11 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         uint256[] memory _tokenIds;
 
         // Record the mint. The returned token IDs correspond to the tiers passed in.
-        (_tokenIds, leftoverAmount) = store.recordMint(
-            _amount,
-            _mintTierIds,
-            false // Not a manual mint
-        );
+        (_tokenIds, leftoverAmount) = store.recordMint({
+            amount: _amount,
+            tierIds: _mintTierIds,
+            isOwnerMint: false // Not a manual mint
+        });
 
         // Get a reference to the number of mints.
         uint256 _mintsLength = _tokenIds.length;
@@ -947,7 +994,13 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
         internal
         returns (bool beneficiaryReceivedTokens)
     {
-        return DefifaHookLib.claimTokensFor(_beneficiary, shareToBeneficiary, outOfTotal, defifaToken, baseProtocolToken);
+        return DefifaHookLib.claimTokensFor({
+            _beneficiary: _beneficiary,
+            shareToBeneficiary: shareToBeneficiary,
+            outOfTotal: outOfTotal,
+            _defifaToken: defifaToken,
+            _baseProtocolToken: baseProtocolToken
+        });
     }
 
     /// @notice Before transferring an NFT, register its first owner (if necessary).
@@ -984,12 +1037,12 @@ contract DefifaHook is JB721Hook, Ownable, IDefifaHook {
 
         // Record the transfer.
         // slither-disable-next-line reentrency-events,calls-loop
-        store.recordTransferForTier(tier.id, from, to);
+        store.recordTransferForTier({tierId: tier.id, from: from, to: to});
 
         // Dont transfer on mint since the delegation will be transferred more efficiently in _processPayment.
         if (from == address(0)) return from;
 
         // Transfer the attestation units.
-        _transferTierAttestationUnits(from, to, tier.id, tier.votingUnits);
+        _transferTierAttestationUnits({_from: from, _to: to, _tierId: tier.id, _amount: tier.votingUnits});
     }
 }

--- a/src/DefifaProjectOwner.sol
+++ b/src/DefifaProjectOwner.sol
@@ -51,10 +51,14 @@ contract DefifaProjectOwner is IERC721Receiver {
         permissionIds[0] = JBPermissionIds.SET_SPLIT_GROUPS;
 
         // Give the defifa deployer contract permission to set splits on this contract's behalf.
-        PERMISSIONS.setPermissionsFor(
-            address(this),
-            JBPermissionsData({operator: address(DEPLOYER), projectId: uint64(tokenId), permissionIds: permissionIds})
-        );
+        PERMISSIONS.setPermissionsFor({
+            account: address(this),
+            permissionsData: JBPermissionsData({
+                operator: address(DEPLOYER),
+                projectId: uint64(tokenId),
+                permissionIds: permissionIds
+            })
+        });
 
         return IERC721Receiver.onERC721Received.selector;
     }

--- a/src/DefifaTokenUriResolver.sol
+++ b/src/DefifaTokenUriResolver.sol
@@ -84,14 +84,15 @@ contract DefifaTokenUriResolver is IDefifaTokenUriResolver, IJB721TokenUriResolv
 
         {
             // Get a reference to the tier.
-            JB721Tier memory _tier = _hook.store().tierOfTokenId(address(_hook), _tokenId, false);
+            JB721Tier memory _tier =
+                _hook.store().tierOfTokenId({hook: address(_hook), tokenId: _tokenId, includeResolvedUri: false});
 
             // Set the tier's name.
             _team = _hook.tierNameOf(_tier.id);
 
             // Check to see if the tier has a URI. Return it if it does.
             if (_tier.encodedIPFSUri != bytes32(0)) {
-                return JBIpfsDecoder.decode(_hook.baseURI(), _tier.encodedIPFSUri);
+                return JBIpfsDecoder.decode({baseUri: _hook.baseURI(), hexString: _tier.encodedIPFSUri});
             }
 
             parts[0] = string("data:application/json;base64,");
@@ -116,13 +117,18 @@ contract DefifaTokenUriResolver is IDefifaTokenUriResolver, IJB721TokenUriResolv
 
                 // Keep a reference to the game pot.
                 (uint256 _gamePot, address _gamePotToken, uint256 _gamePotDecimals) =
-                    _hook.gamePotReporter().currentGamePotOf(_gameId, false);
+                    _hook.gamePotReporter().currentGamePotOf({gameId: _gameId, includeCommitments: false});
 
                 // Include the amount redeemed.
                 _gamePot = _gamePot + _hook.amountRedeemed();
 
                 // Set the pot text.
-                _potText = _formatBalance(_gamePot, _gamePotToken, _gamePotDecimals, _IMG_DECIMAL_FIDELITY);
+                _potText = _formatBalance({
+                    _amount: _gamePot,
+                    _token: _gamePotToken,
+                    _decimals: _gamePotDecimals,
+                    _fidelity: _IMG_DECIMAL_FIDELITY
+                });
 
                 if (_gamePhase == DefifaGamePhase.COUNTDOWN) {
                     _gamePhaseText = "Minting starts soon.";
@@ -158,9 +164,19 @@ contract DefifaTokenUriResolver is IDefifaTokenUriResolver, IJB721TokenUriResolv
                         mulDiv(_gamePot, _hook.cashOutWeightOf(_tokenId), _hook.TOTAL_CASHOUT_WEIGHT());
                     _valueText = !_hook.cashOutWeightIsSet()
                         ? "Awaiting scorecard..."
-                        : _formatBalance(_potPortion, _gamePotToken, _gamePotDecimals, _IMG_DECIMAL_FIDELITY);
+                        : _formatBalance({
+                            _amount: _potPortion,
+                            _token: _gamePotToken,
+                            _decimals: _gamePotDecimals,
+                            _fidelity: _IMG_DECIMAL_FIDELITY
+                        });
                 } else {
-                    _valueText = _formatBalance(_tier.price, _gamePotToken, _gamePotDecimals, _IMG_DECIMAL_FIDELITY);
+                    _valueText = _formatBalance({
+                        _amount: _tier.price,
+                        _token: _gamePotToken,
+                        _decimals: _gamePotDecimals,
+                        _fidelity: _IMG_DECIMAL_FIDELITY
+                    });
                 }
             }
         }

--- a/src/libraries/DefifaHookLib.sol
+++ b/src/libraries/DefifaHookLib.sol
@@ -62,7 +62,7 @@ library DefifaHookLib {
             _lastTierId = tierWeights[_i].id;
 
             // Get the tier.
-            _tier = _store.tierOf(hook, tierWeights[_i].id, false);
+            _tier = _store.tierOf({hook: hook, id: tierWeights[_i].id, includeResolvedUri: false});
 
             // Can't set a cashOut weight for tiers not in category 0.
             if (_tier.category != 0) revert DefifaHook_InvalidTierId();
@@ -107,7 +107,7 @@ library DefifaHookLib {
         uint256 _tierId = _store.tierIdOfToken(tokenId);
 
         // Keep a reference to the tier.
-        JB721Tier memory _tier = _store.tierOf(hook, _tierId, false);
+        JB721Tier memory _tier = _store.tierOf({hook: hook, id: _tierId, includeResolvedUri: false});
 
         // Get the tier's weight.
         uint256 _weight = tierCashOutWeights[_tierId - 1];
@@ -116,7 +116,7 @@ library DefifaHookLib {
         if (_weight == 0) return 0;
 
         // Get the amount of tokens that have already been burned.
-        uint256 _burnedTokens = _store.numberOfBurnedFor(hook, _tierId);
+        uint256 _burnedTokens = _store.numberOfBurnedFor({hook: hook, tierId: _tierId});
 
         // If no tiers were minted, nothing to redeem.
         if (_tier.initialSupply - (_tier.remainingSupply + _burnedTokens) == 0) return 0;
@@ -149,8 +149,13 @@ library DefifaHookLib {
     {
         uint256 _tokenCount = tokenIds.length;
         for (uint256 _i; _i < _tokenCount;) {
-            cumulativeWeight +=
-                computeCashOutWeight(tokenIds[_i], _store, hook, tierCashOutWeights, tokensRedeemedFrom);
+            cumulativeWeight += computeCashOutWeight({
+                tokenId: tokenIds[_i],
+                _store: _store,
+                hook: hook,
+                tierCashOutWeights: tierCashOutWeights,
+                tokensRedeemedFrom: tokensRedeemedFrom
+            });
             unchecked {
                 ++_i;
             }
@@ -187,7 +192,8 @@ library DefifaHookLib {
         // Calculate the amount paid to mint the tokens that are being burned.
         uint256 _cumulativeMintPrice;
         for (uint256 _i; _i < _numberOfTokens; _i++) {
-            _cumulativeMintPrice += _store.tierOfTokenId(hook, tokenIds[_i], false).price;
+            _cumulativeMintPrice +=
+                _store.tierOfTokenId({hook: hook, tokenId: tokenIds[_i], includeResolvedUri: false}).price;
         }
 
         // Calculate the user's claimable amount proportional to what they paid.
@@ -211,7 +217,8 @@ library DefifaHookLib {
     {
         uint256 _numberOfTokenIds = tokenIds.length;
         for (uint256 _i; _i < _numberOfTokenIds; _i++) {
-            cumulativeMintPrice += _store.tierOfTokenId(hook, tokenIds[_i], false).price;
+            cumulativeMintPrice +=
+                _store.tierOfTokenId({hook: hook, tokenId: tokenIds[_i], includeResolvedUri: false}).price;
         }
     }
 
@@ -259,8 +266,8 @@ library DefifaHookLib {
         view
         returns (uint256)
     {
-        JB721Tier memory _tier = _store.tierOf(hook, tierId, false);
-        return _tier.initialSupply - (_tier.remainingSupply + _store.numberOfBurnedFor(hook, tierId));
+        JB721Tier memory _tier = _store.tierOf({hook: hook, id: tierId, includeResolvedUri: false});
+        return _tier.initialSupply - (_tier.remainingSupply + _store.numberOfBurnedFor({hook: hook, tierId: tierId}));
     }
 
     /// @notice Computes the attestation units for tiers during payment processing.
@@ -300,7 +307,8 @@ library DefifaHookLib {
                 }
                 if (_tierIdsToMint[_i] < _currentTierId) revert DefifaHook_BadTierOrder();
                 _currentTierId = _tierIdsToMint[_i];
-                _attestationUnits = _store.tierOf(hook, _currentTierId, false).votingUnits;
+                _attestationUnits =
+                    _store.tierOf({hook: hook, id: _currentTierId, includeResolvedUri: false}).votingUnits;
                 _accumulated = _attestationUnits;
             } else {
                 _accumulated += _attestationUnits;


### PR DESCRIPTION
## Summary
- Standardize slither config (add missing `exclude_low`, `exclude_medium`, `exclude_high`, `disable_color` fields)
- Convert 60+ positional function calls to named parameters across 7 files (DefifaDeployer, DefifaGovernor, DefifaHook, DefifaProjectOwner, DefifaTokenUriResolver, DefifaHookLib)

## Test plan
- [x] `forge build` passes
- [ ] `forge test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)